### PR TITLE
chore: Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build skill/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: skill/dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-unity-bridge"
-version = "0.1.1"
+version = "0.1.2"
 description = "Control Unity Editor from Claude Code"
 readme = "SKILL.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for trusted publishing to PyPI
- Bump version to 0.1.2
- Triggers on version tags (v*)
- Creates GitHub releases automatically

## Prerequisites (done by author)
- [x] Configured PyPI Trusted Publisher at https://pypi.org/manage/account/publishing/

## After merging
1. Create `pypi` environment in repo settings
2. Delete the premature v0.1.2 tag: `git push origin :v0.1.2`
3. Re-tag after merge: `git tag v0.1.2 && git push origin v0.1.2`