### PR TITLE
fix: Exclude CHANGELOG.md.meta from package distribution

### DIFF
--- a/package/.npmignore
+++ b/package/.npmignore
@@ -2,3 +2,4 @@
 Tests/
 Documentation~/
 CHANGELOG.md
+CHANGELOG.md.meta


### PR DESCRIPTION
## Summary
- `.npmignore` excluded `CHANGELOG.md` but not `CHANGELOG.md.meta`, causing an orphaned `.meta` file in the immutable UPM package cache
- Unity repeatedly errors trying to delete the orphan, spamming the console on every asset refresh