### PR TITLE
fix: Handle regular file at install target and add update_package tests

### DIFF
--- a/skill/src/claude_unity_bridge/cli.py
+++ b/skill/src/claude_unity_bridge/cli.py
@@ -558,6 +558,11 @@ def install_skill(verbose: bool = False) -> int:
             print("Remove it manually if you want to use symlink installation.", file=sys.stderr)
             print(f"  rm -rf {target_dir}", file=sys.stderr)
             return EXIT_ERROR
+        else:
+            print(f"Warning: {target_dir} exists and is not a symlink.", file=sys.stderr)
+            print("Remove it manually if you want to use symlink installation.", file=sys.stderr)
+            print(f"  rm {target_dir}", file=sys.stderr)
+            return EXIT_ERROR
 
     # Create symlink
     try:


### PR DESCRIPTION
## Summary
- Fix `install_skill` to properly detect and reject regular files (not just directories) at the symlink target path
- Add missing test coverage for `update_package` function (success, pip failure, subprocess exception, CLI integration)
- Add test for the new regular file detection in `install_skill`

## Test plan
- [x] `pytest skill/tests/test_cli.py -v` passes
- [x] New tests cover edge case where target is a regular file instead of directory/symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)