### PR TITLE
chore: Release v0.1.3

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to the Claude Unity Bridge package will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-02-06
+
+### Fixed
+
+- Handle regular file (not just directory) at install target path
+- Sync all version files (pyproject.toml, __init__.py, package.json)
+
+### Added
+
+- Tests for `update_package` function (success, pip failure, subprocess exception, CLI integration)
+- Test for regular file detection in `install_skill`
+
+## [0.1.2] - 2026-02-05
+
+### Added
+
+- PyPI publish workflow (automated on tag push)
+- Bootstrap installer (`install.sh`) for one-command setup
+- `install-skill` and `update` CLI subcommands
+- PATH detection and auto-configuration in installer
+
+### Changed
+
+- Promoted one-liner install as primary installation approach
+- Excluded CHANGELOG.md.meta from package distribution
+
 ## [0.1.1] - 2026-02-04
 
 ### Fixed
@@ -44,5 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor-only package (no runtime impact)
 - Automatic initialization via `[InitializeOnLoad]`
 
+[0.1.3]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.3
+[0.1.2]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.2
 [0.1.1]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.1
 [0.1.0]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.0

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mxr.claude-bridge",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "displayName": "Claude Unity Bridge",
   "description": "File-based bridge enabling Claude Code to trigger Unity Editor operations (tests, compile, refresh) in a running editor instance.",
   "unity": "2021.3",

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-unity-bridge"
-version = "0.1.2"
+version = "0.1.3"
 description = "Control Unity Editor from Claude Code"
 readme = "SKILL.md"
 license = {text = "Apache-2.0"}

--- a/skill/src/claude_unity_bridge/__init__.py
+++ b/skill/src/claude_unity_bridge/__init__.py
@@ -1,3 +1,3 @@
 """Claude Unity Bridge - Control Unity Editor from Claude Code."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.3"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.3 in all version files (pyproject.toml, __init__.py, package.json)
- Add CHANGELOG entries for v0.1.2 (was missing) and v0.1.3
- Fix version sync: __init__.py and package.json were stuck at 0.1.1

## Version files updated
- `skill/pyproject.toml` → 0.1.3
- `skill/src/claude_unity_bridge/__init__.py` → 0.1.3
- `package/package.json` → 0.1.3
- `package/CHANGELOG.md` → added 0.1.2 + 0.1.3 entries

## Post-merge
Tag `v0.1.3` on main after merge to trigger the publish workflow (PyPI + GH release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)