### PR TITLE
chore: Release 0.1.4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,12 @@
 # Default owners for everything
-* @ManageXR/home-screen
+* @ManageXR/unity-external
 
 # Unity package code
-/Editor/ @ManageXR/home-screen
-/Tests/ @ManageXR/home-screen
+/Editor/ @ManageXR/unity-external
+/Tests/ @ManageXR/unity-external
 
 # Python skill
-/skill/ @ManageXR/home-screen
+/skill/ @ManageXR/unity-external
 
 # CI/CD
-/.github/ @ManageXR/home-screen
+/.github/ @ManageXR/unity-external

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the Claude Unity Bridge package will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-02-09
+
+### Security
+
+- Restrict `.unity-bridge/` directory and file permissions to owner-only on POSIX systems
+- Add UUID validation for command IDs to prevent path traversal attacks
+- Verify response ID matches expected command ID to prevent response spoofing
+- Pin GitHub Actions to commit SHAs to prevent supply chain attacks
+- Pin pre-commit hooks to commit SHAs
+
+### Added
+
+- Dependabot configuration for automated dependency updates (GitHub Actions + pip)
+- `.gitignore` entries for `.unity-bridge/`, `.env`, and secret file patterns
+- CODEOWNERS for `@ManageXR/unity-external` team
+
+### Changed
+
+- Bumped dev dependencies: black 25.11.0, pytest 8.4.2, pytest-cov 7.0.0, flake8 7.3.0, pre-commit 4.3.0
+- Bumped CI dependencies: actions/checkout 6.0.2, actions/setup-python 6.2.0, codecov/codecov-action 5.5.2
+
 ## [0.1.3] - 2026-02-06
 
 ### Fixed
@@ -70,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor-only package (no runtime impact)
 - Automatic initialization via `[InitializeOnLoad]`
 
+[0.1.4]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.4
 [0.1.3]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.3
 [0.1.2]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.2
 [0.1.1]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.1

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mxr.claude-bridge",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "displayName": "Claude Unity Bridge",
   "description": "File-based bridge enabling Claude Code to trigger Unity Editor operations (tests, compile, refresh) in a running editor instance.",
   "unity": "2021.3",

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-unity-bridge"
-version = "0.1.3"
+version = "0.1.4"
 description = "Control Unity Editor from Claude Code"
 readme = "SKILL.md"
 license = {text = "Apache-2.0"}

--- a/skill/src/claude_unity_bridge/__init__.py
+++ b/skill/src/claude_unity_bridge/__init__.py
@@ -1,3 +1,3 @@
 """Claude Unity Bridge - Control Unity Editor from Claude Code."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 across package.json, pyproject.toml, and __init__.py
- Update CHANGELOG with all changes since 0.1.3 (security fixes, dependency bumps, CODEOWNERS)
- Update CODEOWNERS from `@ManageXR/home-screen` to `@ManageXR/unity-external`

## Changes since 0.1.3
### Security
- Restrict `.unity-bridge/` directory permissions to owner-only (POSIX)
- Add UUID validation for command IDs (path traversal prevention)
- Verify response ID matches expected command ID (spoofing prevention)
- Pin GitHub Actions and pre-commit hooks to commit SHAs

### Added
- Dependabot config, `.gitignore` patterns, CODEOWNERS

### Changed
- Dev and CI dependency bumps

## Test plan
- [x] `pytest tests/test_cli.py -v` — 104 tests passing
- [x] All version files in sync (package.json, pyproject.toml, __init__.py)
- [x] CHANGELOG follows Keep a Changelog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)