### PR TITLE
fix: Clean up stale bridge files on every command and on error

### DIFF
--- a/package/Editor/ClaudeBridge.cs
+++ b/package/Editor/ClaudeBridge.cs
@@ -36,6 +36,7 @@ namespace MXR.ClaudeBridge {
             };
 
             EnsureDirectoryExists();
+            CleanupOldResponses();
             EditorApplication.update += PollForCommands;
 
 #if DEBUG


### PR DESCRIPTION
## Summary
- **Always run file cleanup** at the start of every command (removed `--cleanup` flag gate)
- **Add `cleanup_stale_command_file()`** to remove orphaned `command.json` files older than the timeout
- **Include `*.tmp` files** in the TTL sweep alongside `response-*.json`
- **Wrap response handling in `try/finally`** so `cleanup_response_file` runs even on timeout/error
- **Call `CleanupOldResponses()` on Unity-side startup** so stale files from previous sessions are cleaned

## Test plan
- [x] All 113 existing + new tests pass (`pytest tests/test_cli.py -v`)
- [x] Pre-commit hooks pass (black, flake8, etc.)
- [ ] Verify Unity Editor initializes cleanly with stale files present
- [ ] Verify `--cleanup` flag still works (backwards compat, now a no-op)