### PR TITLE
Windows skill install support with copy fallback. PowerShell installer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ File-based bridge enabling Claude Code to trigger Unity Editor operations in a r
 
 ### 1. Install
 
+**macOS / Linux / Git Bash:**
 ```bash
 curl -sSL https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.ps1 | iex
 ```
 
 ### 2. Add to Your Unity Project(s)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,11 +7,24 @@
 
 ## Quick Install
 
+### macOS / Linux / Git Bash
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.sh | bash
 ```
 
-This installs the CLI and Claude Code skill in one command.
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.ps1 | iex
+```
+
+Both installers:
+- Install the `claude-unity-bridge` pip package
+- Add Python scripts directory to your PATH
+- Install the Claude Code skill
+
+**Windows Note:** On Windows without Developer Mode, the skill is installed as a directory copy instead of a symlink. This works seamlessly, but updates require re-running `unity-bridge install-skill`.
 
 ## Manual Install
 
@@ -79,7 +92,11 @@ unity-bridge uninstall-skill
 unity-bridge update
 ```
 
-The skill is installed as a symlink to `~/.claude/skills/unity-bridge/`, pointing to the bundled skill files in the pip package.
+The skill is installed to `~/.claude/skills/unity-bridge/`:
+- **macOS/Linux/Windows with Developer Mode:** Installed as a symlink pointing to the bundled skill files in the pip package (updates automatically with package)
+- **Windows without Developer Mode:** Installed as a directory copy (requires re-running `unity-bridge install-skill` after updates)
+
+To enable symlinks on Windows 10/11, enable Developer Mode in Settings > Update & Security > For developers.
 
 ### Unity Commands
 
@@ -125,9 +142,35 @@ pip install -e ".[dev]"
 unity-bridge install-skill
 ```
 
-## PATH Issues
+## Troubleshooting
+
+### PATH Issues
 
 If `unity-bridge` is not found after pip install, the pip scripts directory may not be in your PATH. You can:
 
 1. Add the pip scripts directory to your PATH
 2. Use the module directly: `python -m claude_unity_bridge.cli install-skill`
+
+### Windows Symlink Permissions
+
+On Windows, creating symlinks requires either:
+- Administrator privileges, or
+- Developer Mode enabled
+
+If you see `[WinError 1314] A required privilege is not held by the client`, the installer will automatically fall back to copying the skill directory. This works perfectly fine, but updates require re-running `unity-bridge install-skill`.
+
+**To enable symlinks (optional):**
+1. Open Settings > Update & Security > For developers
+2. Enable "Developer Mode"
+3. Restart your terminal
+4. Run `unity-bridge install-skill` again
+
+### Python Version
+
+Make sure you're using Python 3.8 or later:
+
+```bash
+python --version
+# or
+python3 --version
+```

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,88 @@
+# Claude Unity Bridge - Quick Installer (PowerShell)
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.ps1 | iex
+#
+# Or download and run:
+#   .\install.ps1
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Installing Claude Unity Bridge..." -ForegroundColor Cyan
+Write-Host ""
+
+# Check Python
+$pythonCmd = $null
+foreach ($cmd in @("python", "python3", "py")) {
+    try {
+        $version = & $cmd --version 2>&1
+        if ($version -match "Python 3\.") {
+            $pythonCmd = $cmd
+            break
+        }
+    }
+    catch {
+        continue
+    }
+}
+
+if (-not $pythonCmd) {
+    Write-Host "Error: Python 3 is required but not installed." -ForegroundColor Red
+    Write-Host "Download from: https://www.python.org/downloads/" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Found Python: $pythonCmd" -ForegroundColor Green
+
+# Install via pip (user-site to avoid permission issues)
+Write-Host ""
+Write-Host "Installing pip package..." -ForegroundColor Cyan
+& $pythonCmd -m pip install --user --upgrade claude-unity-bridge
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: pip installation failed" -ForegroundColor Red
+    exit 1
+}
+
+# Get Python user scripts directory
+$userBase = & $pythonCmd -m site --user-base
+$scriptsDir = Join-Path $userBase "Scripts"
+
+# Add to PATH if not already there
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -notlike "*$scriptsDir*") {
+    Write-Host "Adding Python scripts to user PATH..." -ForegroundColor Cyan
+
+    $newPath = if ($userPath) { "$userPath;$scriptsDir" } else { $scriptsDir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+
+    # Update current session PATH
+    $env:Path = "$env:Path;$scriptsDir"
+
+    Write-Host "PATH updated. You may need to restart your terminal for changes to take effect." -ForegroundColor Yellow
+}
+else {
+    Write-Host "Python scripts directory already in PATH" -ForegroundColor Green
+}
+
+# Install skill
+Write-Host ""
+Write-Host "Installing Claude Code skill..." -ForegroundColor Cyan
+& $pythonCmd -m claude_unity_bridge.cli install-skill
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Error: Skill installation failed" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Installation complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  1. Add the Unity package to your project:"
+Write-Host "     Window > Package Manager > + > Add package from git URL..."
+Write-Host "     https://github.com/ManageXR/claude-unity-bridge.git?path=package"
+Write-Host ""
+Write-Host "  2. Open Claude Code in your Unity project directory"
+Write-Host ""
+Write-Host "  3. Ask Claude naturally: " -NoNewline
+Write-Host '"Run the Unity tests"' -ForegroundColor Yellow
+Write-Host ""


### PR DESCRIPTION
## Summary
Fixes https://github.com/ManageXR/claude-unity-bridge/issues/13

Fall back to directory copy approach when symlink creation fails when not having Admin privileges or not being in Developer mode.

Add install.ps1 for one-line PowerShell installation. and update README with instructions.