### PR TITLE
chore: Correct script/test names and package name in docs

### DIFF
--- a/.TestProject/README.md
+++ b/.TestProject/README.md
@@ -72,7 +72,7 @@ With Unity Editor open and the .TestProject loaded, test the Python skill script
 ```bash
 # From repository root
 cd skill
-python3 scripts/unity_command.py get-status
+python3 scripts/cli.py get-status
 ```
 
 **Expected output:**
@@ -91,16 +91,16 @@ Try other commands to validate full functionality:
 
 ```bash
 # Compile scripts
-python3 scripts/unity_command.py compile
+python3 scripts/cli.py compile
 
 # Refresh asset database
-python3 scripts/unity_command.py refresh
+python3 scripts/cli.py refresh
 
 # Get console logs
-python3 scripts/unity_command.py get-console-logs --limit 10
+python3 scripts/cli.py get-console-logs --limit 10
 
 # Run tests (if any test assemblies exist)
-python3 scripts/unity_command.py run-tests --mode EditMode
+python3 scripts/cli.py run-tests --mode EditMode
 ```
 
 ## Troubleshooting
@@ -156,11 +156,11 @@ open -a "Unity" .TestProject/
 
 # 3. Test changes via Python skill script
 cd skill
-python3 scripts/unity_command.py get-status
-python3 scripts/unity_command.py compile
+python3 scripts/cli.py get-status
+python3 scripts/cli.py compile
 
 # 4. Run pytest tests for Python script
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 
 # 5. Commit when all tests pass
 ```
@@ -217,10 +217,10 @@ To use a different Unity version:
 open -a "Unity" .TestProject/
 
 # Test bridge
-cd skill && python3 scripts/unity_command.py get-status
+cd skill && python3 scripts/cli.py get-status
 
 # Run all commands
-python3 scripts/unity_command.py --help
+python3 scripts/cli.py --help
 
 # Close Unity
 # Use Cmd+Q or Unity > Quit

--- a/.TestProject/VALIDATION.md
+++ b/.TestProject/VALIDATION.md
@@ -23,31 +23,31 @@ All bridge commands tested and working:
 1. **get-status** ✓
    ```bash
    cd .TestProject
-   python3 ../skill/scripts/unity_command.py get-status
+   python3 ../skill/scripts/cli.py get-status
    ```
    Output: Compilation Ready, Play Mode: Editing
 
 2. **compile** ✓
    ```bash
-   python3 ../skill/scripts/unity_command.py compile
+   python3 ../skill/scripts/cli.py compile
    ```
    Output: Compilation Status: running
 
 3. **refresh** ✓
    ```bash
-   python3 ../skill/scripts/unity_command.py refresh
+   python3 ../skill/scripts/cli.py refresh
    ```
    Output: Asset Database Refreshed (0.04s)
 
 4. **get-console-logs** ✓
    ```bash
-   python3 ../skill/scripts/unity_command.py get-console-logs --limit 5
+   python3 ../skill/scripts/cli.py get-console-logs --limit 5
    ```
    Output: Successfully retrieved last 5 console logs with full stack traces
 
 5. **run-tests** ✓
    ```bash
-   python3 ../skill/scripts/unity_command.py run-tests --mode EditMode
+   python3 ../skill/scripts/cli.py run-tests --mode EditMode
    ```
    Output: 0 tests (expected - package has no Unity tests yet, see AGENTS.md)
 
@@ -65,7 +65,7 @@ All bridge commands tested and working:
 ### ❌ Wrong (times out):
 ```bash
 cd /path/to/claude-unity-bridge
-python3 skill/scripts/unity_command.py get-status
+python3 skill/scripts/cli.py get-status
 ```
 
 This writes to `/path/to/claude-unity-bridge/.unity-bridge/` but Unity looks at project's `.unity-bridge/`.
@@ -73,7 +73,7 @@ This writes to `/path/to/claude-unity-bridge/.unity-bridge/` but Unity looks at 
 ### ✅ Correct:
 ```bash
 cd /path/to/claude-unity-bridge/.TestProject
-python3 ../skill/scripts/unity_command.py get-status
+python3 ../skill/scripts/cli.py get-status
 ```
 
 This writes to `.TestProject/.unity-bridge/` where Unity is polling.
@@ -104,19 +104,19 @@ Edit files in `Editor/`, `Editor/Commands/`, etc. Changes reflect immediately du
 cd .TestProject
 
 # Check Unity status
-python3 ../skill/scripts/unity_command.py get-status
+python3 ../skill/scripts/cli.py get-status
 
 # Trigger compilation
-python3 ../skill/scripts/unity_command.py compile
+python3 ../skill/scripts/cli.py compile
 
 # Refresh assets
-python3 ../skill/scripts/unity_command.py refresh
+python3 ../skill/scripts/cli.py refresh
 
 # Get console logs
-python3 ../skill/scripts/unity_command.py get-console-logs --limit 10
+python3 ../skill/scripts/cli.py get-console-logs --limit 10
 
 # Run tests (when Unity tests exist)
-python3 ../skill/scripts/unity_command.py run-tests --mode EditMode
+python3 ../skill/scripts/cli.py run-tests --mode EditMode
 ```
 
 ### 4. Run Python Tests
@@ -125,7 +125,7 @@ Test the skill script itself:
 
 ```bash
 cd skill
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 ```
 
 ### 5. Check Unity Console
@@ -189,7 +189,7 @@ All commands processed successfully with proper callbacks.
 - [x] Unity Package Manager shows "Claude Unity Bridge" as "Local" package
 - [x] Unity Console shows `[ClaudeBridge]` initialization and processing messages
 - [x] `.unity-bridge/` directory created by Unity on startup
-- [x] `python3 ../skill/scripts/unity_command.py get-status` returns success (exit code 0)
+- [x] `python3 ../skill/scripts/cli.py get-status` returns success (exit code 0)
 - [x] Response shows correct Unity version and project state
 - [x] All bridge commands work (compile, refresh, get-console-logs, run-tests)
 - [x] Command/response files created and cleaned up properly
@@ -219,7 +219,7 @@ The integration test harness is **ready for use**. When working on Unity Bridge:
 
 1. Open `.TestProject` in Unity
 2. Make changes to package code
-3. Test with `cd .TestProject && python3 ../skill/scripts/unity_command.py <command>`
+3. Test with `cd .TestProject && python3 ../skill/scripts/cli.py <command>`
 4. Check Unity Console for results
 5. Run pytest for Python script tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is a Unity package (`com.managexr.claude-bridge`) that enables Claude Code to control Unity Editor operations via a file-based protocol. The package has two components:
+This is a Unity package (`com.mxr.claude-bridge`) that enables Claude Code to control Unity Editor operations via a file-based protocol. The package has two components:
 
 1. **Unity Package** - C# code that runs in Unity Editor, polls for commands, executes them
 2. **Claude Code Skill** - Python script + documentation that Claude uses to send commands
@@ -11,7 +11,7 @@ This is a Unity package (`com.managexr.claude-bridge`) that enables Claude Code 
 
 ## Project Structure
 
-### Unity Package (Root)
+### Unity Package (package/)
 - `Editor/` - C# command implementations for Unity
   - `ClaudeBridge.cs` - Main coordinator, command dispatcher
   - `Commands/` - Individual command implementations (ICommand interface)
@@ -20,7 +20,7 @@ This is a Unity package (`com.managexr.claude-bridge`) that enables Claude Code 
 - `README.md` - Package documentation and protocol specification
 
 ### Claude Code Skill (skill/)
-- `scripts/unity_command.py` - **THE CORE** - Handles all command execution
+- `scripts/cli.py` - **THE CORE** - Handles all command execution
 - `SKILL.md` - Main documentation with YAML frontmatter
 - `references/` - Extended documentation
   - `COMMANDS.md` - Complete command reference
@@ -53,25 +53,25 @@ pre-commit run --all-files
 
 ### Testing the Python Script
 ```bash
-# Run pytest suite (22 tests)
+# Run pytest suite
 cd skill
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 
 # Run with coverage
-pytest tests/test_unity_command.py --cov=scripts --cov-report=term-missing
+pytest tests/test_cli.py --cov=scripts --cov-report=term-missing
 
 # Test script help
-python3 scripts/unity_command.py --help
+python3 scripts/cli.py --help
 ```
 
 ### Testing with Unity
 ```bash
 # These require Unity Editor to be running
-python3 skill/scripts/unity_command.py get-status
-python3 skill/scripts/unity_command.py compile
-python3 skill/scripts/unity_command.py run-tests --mode EditMode
-python3 skill/scripts/unity_command.py get-console-logs --limit 10 --filter Error
-python3 skill/scripts/unity_command.py refresh
+python3 skill/scripts/cli.py get-status
+python3 skill/scripts/cli.py compile
+python3 skill/scripts/cli.py run-tests --mode EditMode
+python3 skill/scripts/cli.py get-console-logs --limit 10 --filter Error
+python3 skill/scripts/cli.py refresh
 ```
 
 ### Git Workflow
@@ -92,7 +92,7 @@ git commit -m "test: Add tests and CI"
 
 ## Coding Style
 
-### Python (skill/scripts/unity_command.py)
+### Python (skill/scripts/cli.py)
 - PEP 8 compliant
 - 100-character line limit
 - Type hints where helpful
@@ -119,8 +119,8 @@ git commit -m "test: Add tests and CI"
 
 ### Python Script Tests (Critical)
 - **Framework**: pytest
-- **Coverage Goal**: ~95% of unity_command.py
-- **Location**: `skill/tests/test_unity_command.py`
+- **Coverage Goal**: ~95% of cli.py
+- **Location**: `skill/tests/test_cli.py`
 - **Run Before Commit**: Always run pytest before committing script changes
 - **CI**: GitHub Actions runs on Python 3.8-3.11, Ubuntu/macOS/Windows
 
@@ -146,10 +146,10 @@ git commit -m "test: Add tests and CI"
   - ⏳ Phase 6: CI/CD integration (deferred - licensing discussion needed)
 
 ### Test-Driven Development
-When modifying `unity_command.py`:
+When modifying `cli.py`:
 1. Write/update pytest tests first
 2. Implement changes
-3. Run `pytest tests/test_unity_command.py -v`
+3. Run `pytest tests/test_cli.py -v`
 4. Check coverage: `pytest --cov=scripts`
 5. All tests must pass before committing
 
@@ -157,10 +157,10 @@ When modifying `unity_command.py`:
 
 ### NEVER Do These Things
 
-1. **NEVER modify unity_command.py without updating tests**
+1. **NEVER modify cli.py without updating tests**
    - The script is the foundation of reliability
    - Untested changes break the deterministic guarantee
-   - Always update `skill/tests/test_unity_command.py`
+   - Always update `skill/tests/test_cli.py`
 
 2. **NEVER modify Unity commands without updating Unity tests**
    - Command implementations must maintain test coverage
@@ -180,7 +180,7 @@ When modifying `unity_command.py`:
 
 5. **NEVER change response format without updating formatters**
    - Unity-side response format is in `Models/CommandResponse.cs`
-   - Python formatters are in `unity_command.py` (format_* functions)
+   - Python formatters are in `cli.py` (format_* functions)
    - These must stay in sync
 
 6. **NEVER remove error handling from commands**
@@ -192,7 +192,7 @@ When modifying `unity_command.py`:
 
 1. **ALWAYS run pytest before committing Python changes**
    ```bash
-   cd skill && pytest tests/test_unity_command.py -v
+   cd skill && pytest tests/test_cli.py -v
    ```
 
 2. **ALWAYS run Unity tests before committing C# changes**
@@ -269,10 +269,10 @@ When modifying `unity_command.py`:
 
 3. **Test with Python script**:
    ```bash
-   python3 skill/scripts/unity_command.py your-command
+   python3 skill/scripts/cli.py your-command
    ```
 
-4. **Optional: Add Python Formatter** in `unity_command.py`:
+4. **Optional: Add Python Formatter** in `cli.py`:
    ```python
    def format_your_command(response: Dict, status: str, duration: float) -> str:
        # Custom formatting logic
@@ -337,16 +337,16 @@ test: Add pytest tests for scene validation
 
 2. **Add Python formatter (optional)**
    ```bash
-   # Edit skill/scripts/unity_command.py
+   # Edit skill/scripts/cli.py
    # Add format_your_command() function
    # Update format_response() dispatch
    ```
 
 3. **Write tests**
    ```bash
-   # Edit skill/tests/test_unity_command.py
+   # Edit skill/tests/test_cli.py
    # Add TestFormatYourCommand class
-   cd skill && pytest tests/test_unity_command.py -v
+   cd skill && pytest tests/test_cli.py -v
    ```
 
 4. **Update documentation**
@@ -372,7 +372,7 @@ test: Add pytest tests for scene validation
 
 1. **Check Unity is running**
    ```bash
-   python3 skill/scripts/unity_command.py get-status --verbose
+   python3 skill/scripts/cli.py get-status --verbose
    ```
 
 2. **Inspect command/response files**
@@ -389,7 +389,7 @@ test: Add pytest tests for scene validation
 
 4. **Test with timeout and verbose**
    ```bash
-   python3 skill/scripts/unity_command.py compile --timeout 60 --verbose
+   python3 skill/scripts/cli.py compile --timeout 60 --verbose
    ```
 
 ## Architecture Patterns
@@ -473,7 +473,7 @@ test: Add pytest tests for scene validation
 
 ### Tests Failing After Script Changes
 **Cause**: Tests out of sync with implementation
-**Fix**: Update `skill/tests/test_unity_command.py` to match new behavior
+**Fix**: Update `skill/tests/test_cli.py` to match new behavior
 
 ## Contributing Guidelines
 
@@ -552,23 +552,23 @@ The Unity package now has comprehensive test coverage:
 ### Most Common Commands
 ```bash
 # Get Unity status
-python3 skill/scripts/unity_command.py get-status
+python3 skill/scripts/cli.py get-status
 
 # Run EditMode tests
-python3 skill/scripts/unity_command.py run-tests --mode EditMode
+python3 skill/scripts/cli.py run-tests --mode EditMode
 
 # Check for errors
-python3 skill/scripts/unity_command.py get-console-logs --filter Error
+python3 skill/scripts/cli.py get-console-logs --filter Error
 
 # Test Python script
-cd skill && pytest tests/test_unity_command.py -v
+cd skill && pytest tests/test_cli.py -v
 ```
 
 ### Key Files to Know
-- `skill/scripts/unity_command.py` - THE deterministic command executor
+- `skill/scripts/cli.py` - THE deterministic command executor
 - `Editor/ClaudeBridge.cs` - Unity command dispatcher
 - `Editor/Models/CommandResponse.cs` - Response structure
-- `skill/tests/test_unity_command.py` - Python test suite
+- `skill/tests/test_cli.py` - Python test suite
 - `skill/SKILL.md` - User-facing documentation
 
 ### Exit Codes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,13 @@ Before working on this repository, you must read:
 From AGENTS.md, these are the most important rules:
 
 ### NEVER:
-- Modify `unity_command.py` without updating pytest tests
+- Modify `cli.py` without updating pytest tests
 - Use in-context file I/O for Unity commands (always use the Python script)
 - Write to Unity project files while Unity Editor is running
 - Remove error handling from command implementations
 
 ### ALWAYS:
-- Run `pytest tests/test_unity_command.py -v` before committing Python changes
+- Run `pytest tests/test_cli.py -v` before committing Python changes
 - Use the deterministic Python script for all Unity commands
 - Update documentation when changing behavior
 - Follow the 3-commit structure for features (core, docs, testing)
@@ -29,15 +29,15 @@ From AGENTS.md, these are the most important rules:
 ```bash
 # Test the Python skill script
 cd skill
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 
 # Test with Unity (requires Unity Editor running)
-python3 scripts/unity_command.py get-status
+python3 scripts/cli.py get-status
 ```
 
 ## Why This Matters
 
-The Unity Bridge uses a **deterministic Python script** (`skill/scripts/unity_command.py`) as the foundation of reliability. This script guarantees consistent UUID generation, file handling, polling behavior, and error handling across all Claude sessions.
+The Unity Bridge uses a **deterministic Python script** (`skill/scripts/cli.py`) as the foundation of reliability. This script guarantees consistent UUID generation, file handling, polling behavior, and error handling across all Claude sessions.
 
 Without reading AGENTS.md, you risk:
 - Breaking the deterministic guarantee

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Please confirm tests pass before submitting PRs that modify `Editor/` or `Tests/
 - Follow existing patterns and conventions in the codebase
 - Keep changes focused and minimal
 - No major refactors without prior discussion in an issue
-- Maintain the deterministic behavior of `unity_command.py`
+- Maintain the deterministic behavior of `cli.py`
 
 ## PR Process
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,5 +26,5 @@ comment:
 flags:
   python-skill:
     paths:
-      - skill/scripts/
+      - skill/src/
     carryforward: true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ package/                     # Unity package (UPM)
 
 skill/                       # Claude Code skill (Python)
 ├── scripts/
-│   └── unity_command.py     # Deterministic command script
+│   └── cli.py               # Deterministic command script
 ├── references/
 │   ├── COMMANDS.md          # Complete command specification
 │   └── EXTENDING.md         # Guide for adding custom commands

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -59,7 +59,7 @@ Add this line to your project's `Packages/manifest.json`:
 ```json
 {
   "dependencies": {
-    "com.managexr.claude-bridge": "https://github.com/ManageXR/claude-unity-bridge.git?path=package"
+    "com.mxr.claude-bridge": "https://github.com/ManageXR/claude-unity-bridge.git?path=package"
   }
 }
 ```

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity
-description: Execute Unity Editor commands (run tests, compile, get logs, refresh assets) via file-based bridge. Auto-activates for Unity-related tasks. Requires com.managexr.claude-bridge package installed in Unity project.
+description: Execute Unity Editor commands (run tests, compile, get logs, refresh assets) via file-based bridge. Auto-activates for Unity-related tasks. Requires com.mxr.claude-bridge package installed in Unity project.
 ---
 
 # Unity Bridge Skill
@@ -22,7 +22,7 @@ The Unity Bridge enables Claude Code to trigger operations in a running Unity Ed
 
 ## Requirements
 
-1. **Unity Package:** Install `com.managexr.claude-bridge` in your Unity project
+1. **Unity Package:** Install `com.mxr.claude-bridge` in your Unity project
    - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git`
    - See main package README for installation instructions
 

--- a/skill/TESTING.md
+++ b/skill/TESTING.md
@@ -9,10 +9,10 @@ This document describes how to test the Unity Bridge Python script.
 pip install -r requirements-dev.txt
 
 # Run all tests
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 
 # Run with coverage
-pytest tests/test_unity_command.py -v --cov=scripts --cov-report=html
+pytest tests/test_cli.py -v --cov=scripts --cov-report=html
 ```
 
 ## Test Structure
@@ -31,25 +31,25 @@ The test suite uses pytest and covers:
 
 ```bash
 cd skill
-pytest tests/test_unity_command.py -v
+pytest tests/test_cli.py -v
 ```
 
 ### Specific Test Class
 
 ```bash
-pytest tests/test_unity_command.py::TestFormatTestResults -v
+pytest tests/test_cli.py::TestFormatTestResults -v
 ```
 
 ### Specific Test
 
 ```bash
-pytest tests/test_unity_command.py::TestFormatTestResults::test_all_tests_passed -v
+pytest tests/test_cli.py::TestFormatTestResults::test_all_tests_passed -v
 ```
 
 ### With Coverage
 
 ```bash
-pytest tests/test_unity_command.py --cov=scripts --cov-report=term-missing
+pytest tests/test_cli.py --cov=scripts --cov-report=term-missing
 ```
 
 This shows which lines are not covered by tests.
@@ -57,7 +57,7 @@ This shows which lines are not covered by tests.
 ### Generate HTML Coverage Report
 
 ```bash
-pytest tests/test_unity_command.py --cov=scripts --cov-report=html
+pytest tests/test_cli.py --cov=scripts --cov-report=html
 open htmlcov/index.html
 ```
 
@@ -96,34 +96,34 @@ Open Unity Editor with a project that has the Claude Unity Bridge package instal
 cd skill
 
 # Check editor status
-python3 scripts/unity_command.py get-status
+python3 scripts/cli.py get-status
 
 # Trigger compilation
-python3 scripts/unity_command.py compile
+python3 scripts/cli.py compile
 
 # Run tests
-python3 scripts/unity_command.py run-tests --mode EditMode
+python3 scripts/cli.py run-tests --mode EditMode
 
 # Get console logs
-python3 scripts/unity_command.py get-console-logs --limit 10 --filter Error
+python3 scripts/cli.py get-console-logs --limit 10 --filter Error
 
 # Refresh assets
-python3 scripts/unity_command.py refresh
+python3 scripts/cli.py refresh
 ```
 
 ### 3. Test Error Scenarios
 
 ```bash
 # Close Unity to test "Unity not running" error
-python3 scripts/unity_command.py get-status
+python3 scripts/cli.py get-status
 # Should error: "Unity Editor not detected"
 
 # Test timeout
-python3 scripts/unity_command.py get-status --timeout 2
+python3 scripts/cli.py get-status --timeout 2
 # If Unity is slow to respond, will timeout
 
 # Test verbose mode
-python3 scripts/unity_command.py compile --verbose
+python3 scripts/cli.py compile --verbose
 # Shows detailed execution progress
 ```
 
@@ -141,7 +141,7 @@ See `.github/workflows/test-skill.yml` for the CI configuration.
 
 When adding new functionality to the Python script:
 
-1. Add test cases to `tests/test_unity_command.py`
+1. Add test cases to `tests/test_cli.py`
 2. Follow the existing test structure
 3. Use descriptive test names
 4. Test both success and failure cases
@@ -172,7 +172,7 @@ If you see `ModuleNotFoundError: No module named 'unity_command'`:
 cd skill
 
 # Run tests from there
-pytest tests/test_unity_command.py
+pytest tests/test_cli.py
 ```
 
 ### Path Issues
@@ -199,7 +199,7 @@ def test_something(tmp_path):
 
 ## Test Coverage Goals
 
-Current coverage: ~95% of `unity_command.py`
+Current coverage: ~95% of `cli.py`
 
 Not covered (intentionally):
 - `main()` function (CLI entry point, tested manually)
@@ -232,7 +232,7 @@ def test_polling_performance(tmp_path):
 ### Verbose Output
 
 ```bash
-pytest tests/test_unity_command.py -v -s
+pytest tests/test_cli.py -v -s
 ```
 
 The `-s` flag shows print statements.
@@ -240,7 +240,7 @@ The `-s` flag shows print statements.
 ### Debug Specific Test
 
 ```bash
-pytest tests/test_unity_command.py::TestWriteCommand::test_write_command_creates_file -v -s
+pytest tests/test_cli.py::TestWriteCommand::test_write_command_creates_file -v -s
 ```
 
 ### Use pdb Debugger
@@ -257,7 +257,7 @@ def test_something():
 Run:
 
 ```bash
-pytest tests/test_unity_command.py::test_something -s
+pytest tests/test_cli.py::test_something -s
 ```
 
 ## Resources

--- a/skill/src/claude_unity_bridge/skill/SKILL.md
+++ b/skill/src/claude_unity_bridge/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity
-description: Execute Unity Editor commands (run tests, compile, get logs, refresh assets) via file-based bridge. Auto-activates for Unity-related tasks. Requires com.managexr.claude-bridge package installed in Unity project.
+description: Execute Unity Editor commands (run tests, compile, get logs, refresh assets) via file-based bridge. Auto-activates for Unity-related tasks. Requires com.mxr.claude-bridge package installed in Unity project.
 ---
 
 # Unity Bridge Skill
@@ -22,7 +22,7 @@ The Unity Bridge enables Claude Code to trigger operations in a running Unity Ed
 
 ## Requirements
 
-1. **Unity Package:** Install `com.managexr.claude-bridge` in your Unity project
+1. **Unity Package:** Install `com.mxr.claude-bridge` in your Unity project
    - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git`
    - See main package README for installation instructions
 


### PR DESCRIPTION
- Rename unity_command.py to cli.py and test_unity_command.py to test_cli.py wherever mentioned

- Use com.mxr.claude-bridge consistently (replace com.managexr.claude-bridge) in SKILL.md and INSTALLATION.md

- Use correct python source path in codecov.yml