### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Claude Unity Bridge package will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-02-17
+
+### Added
+
+- `play` command - Toggle Play Mode on/off
+- `pause` command - Toggle pause while in Play Mode
+- `step` command - Advance one frame while paused
+- `IEditorPlayMode` interface abstracting `EditorApplication` for testability
+- Full Moq-based test coverage for play/pause/step commands
+
+### Fixed
+
+- Play command response now reports intended play mode state instead of stale pre-transition value
+
 ## [0.2.0] - 2026-02-11
 
 ### Fixed
@@ -139,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor-only package (no runtime impact)
 - Automatic initialization via `[InitializeOnLoad]`
 
+[0.2.1]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.2.1
 [0.2.0]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.2.0
 [0.1.5]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.5
 [0.1.4]: https://github.com/ManageXR/claude-unity-bridge/releases/tag/v0.1.4

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mxr.claude-bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "displayName": "ManageXR Claude Unity Bridge",
   "description": "File-based bridge enabling Claude Code to trigger Unity Editor operations (tests, compile, refresh) in a running editor instance.",
   "unity": "2021.3",

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-unity-bridge"
-version = "0.2.0"
+version = "0.2.1"
 description = "Control Unity Editor from Claude Code"
 readme = "SKILL.md"
 license = {text = "Apache-2.0"}

--- a/skill/src/claude_unity_bridge/__init__.py
+++ b/skill/src/claude_unity_bridge/__init__.py
@@ -1,3 +1,3 @@
 """Claude Unity Bridge - Control Unity Editor from Claude Code."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.1 across all three version files (pyproject.toml, __init__.py, package.json)
- Add CHANGELOG entry for play/pause/step commands and play mode display fix

## Release Notes (v0.2.1)

### Added
- `play` command - Toggle Play Mode on/off
- `pause` command - Toggle pause while in Play Mode
- `step` command - Advance one frame while paused
- `IEditorPlayMode` interface abstracting `EditorApplication` for testability
- Full Moq-based test coverage for play/pause/step commands

### Fixed
- Play command response now reports intended play mode state instead of stale pre-transition value

## Post-merge

Tag `v0.2.1` on main after merge to trigger PyPI publish workflow.