### PR TITLE
fix: Add ?path=package to git URL in SKILL.md

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,7 +24,7 @@ The Unity Bridge enables Claude Code to trigger operations in a running Unity Ed
 ## Requirements
 
 1. **Unity Package:** Install `com.mxr.claude-bridge` in your Unity project
-   - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git`
+   - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git?path=package`
    - See main package README for installation instructions
 
 2. **Unity Editor:** Must be open with your project loaded

--- a/skill/src/claude_unity_bridge/skill/SKILL.md
+++ b/skill/src/claude_unity_bridge/skill/SKILL.md
@@ -23,7 +23,7 @@ The Unity Bridge enables Claude Code to trigger operations in a running Unity Ed
 ## Requirements
 
 1. **Unity Package:** Install `com.mxr.claude-bridge` in your Unity project
-   - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git`
+   - Via Package Manager: `https://github.com/ManageXR/claude-unity-bridge.git?path=package`
    - See main package README for installation instructions
 
 2. **Unity Editor:** Must be open with your project loaded


### PR DESCRIPTION
## Summary

- The Unity Package Manager git URL in both `skill/SKILL.md` and `skill/src/claude_unity_bridge/skill/SKILL.md` was missing the `?path=package` suffix
- Without this suffix, Unity Package Manager cannot locate the package within the repository since it lives in the `package/` subdirectory
- The `README.md` already had the correct URL; this fix brings both [SKILL.md](http://SKILL.md) files into alignment

## Test plan

- [x] Verify the updated URL in `skill/SKILL.md` line 27 includes `?path=package`
- [x] Verify the updated URL in `skill/src/claude_unity_bridge/skill/SKILL.md` line 26 includes `?path=package`
- [x] Confirm the URL matches the one in `README.md`