### PR TITLE
fix: Add play mode control to README features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ File-based bridge enabling Claude Code to trigger Unity Editor operations in a r
 - **Refresh** — Force asset database refresh
 - **Get Status** — Check editor compilation/update state
 - **Get Console Logs** — Retrieve Unity console output
+- **Play Mode Control** — Play, pause, and step through frames
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
## Summary

- Add "Play Mode Control" to the README features list, documenting the play, pause, and step commands

## Context

The play, pause, and step commands for Play Mode control were added in v0.2.1 (PR #36), but the README features list was not updated to reflect these new capabilities. This PR adds the missing feature entry.

## Test plan

- [x] Verify the new line appears correctly in the rendered README features list
- [x] No code changes; documentation only