### PR TITLE
fix: Add --user flag to pip install in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ fi
 
 # Install via pip
 echo "Installing pip package..."
-python3 -m pip install --upgrade claude-unity-bridge
+python3 -m pip install --user --upgrade claude-unity-bridge
 
 # Get Python user scripts directory
 PYTHON_BIN="$(python3 -m site --user-base)/bin"


### PR DESCRIPTION
## Summary

- Add `--user` flag to the `pip install` command in `install.sh` (line 23), matching the behavior already present in `install.ps1` (line 40)

## Why

The PowerShell installer (`install.ps1`) already correctly uses `--user` for pip install:

```powershell
& $pythonCmd -m pip install --user --upgrade claude-unity-bridge
```

But the bash installer (`install.sh`) was missing it:

```bash
python3 -m pip install --upgrade claude-unity-bridge
```

Without `--user`, the bash installer fails on:

- **macOS with Homebrew Python** -- Homebrew Python disallows system-level pip installs by default
- **Recent Ubuntu/Debian (PEP 668)** -- externally-managed Python environments reject `pip install` without `--user` or a virtual environment

The `--user` flag installs to the user site-packages directory, which avoids permission issues and is consistent with the rest of the script (which already references `python3 -m site --user-base` for PATH configuration).

## Test plan

- [ ] Run `install.sh` on macOS with Homebrew Python and verify it installs successfully
- [ ] Run `install.sh` on Ubuntu 24.04 and verify it installs successfully
- [x] Verify `install.ps1` behavior is unchanged