### PR TITLE
chore: Bump version to 0.2.2

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mxr.claude-bridge",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "displayName": "ManageXR Claude Unity Bridge",
   "description": "File-based bridge enabling Claude Code to trigger Unity Editor operations (tests, compile, refresh) in a running editor instance.",
   "unity": "2021.3",

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-unity-bridge"
-version = "0.2.1"
+version = "0.2.2"
 description = "Control Unity Editor from Claude Code"
 readme = "SKILL.md"
 license = {text = "Apache-2.0"}

--- a/skill/src/claude_unity_bridge/__init__.py
+++ b/skill/src/claude_unity_bridge/__init__.py
@@ -1,3 +1,3 @@
 """Claude Unity Bridge - Control Unity Editor from Claude Code."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 across `__init__.py`, `pyproject.toml`, and `package.json`
- Pre-launch fixes: synced SKILL.md, fixed git URLs, updated README, fixed installer

## Changes
- `skill/src/claude_unity_bridge/__init__.py`: 0.2.1 → 0.2.2
- `skill/pyproject.toml`: 0.2.1 → 0.2.2
- `package/package.json`: 0.2.1 → 0.2.2