### PR TITLE
chore: Polish PyPI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # 🌉 Claude Unity Bridge
 
+[![PyPI](https://img.shields.io/pypi/v/claude-unity-bridge)](https://pypi.org/project/claude-unity-bridge/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/claude-unity-bridge)](https://pypi.org/project/claude-unity-bridge/)
 [![GitHub release](https://img.shields.io/github/v/release/ManageXR/claude-unity-bridge)](https://github.com/ManageXR/claude-unity-bridge/releases)
-![CI](https://github.com/ManageXR/claude-unity-bridge/actions/workflows/test-skill.yml/badge.svg)
+[![CI](https://github.com/ManageXR/claude-unity-bridge/actions/workflows/test-skill.yml/badge.svg)](https://github.com/ManageXR/claude-unity-bridge/actions/workflows/test-skill.yml)
 [![codecov](https://codecov.io/gh/ManageXR/claude-unity-bridge/graph/badge.svg?token=3PHF2GXHON)](https://codecov.io/gh/ManageXR/claude-unity-bridge)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 ![Unity 2021.3+](https://img.shields.io/badge/Unity-2021.3%2B-black.svg)
+![Python 3.8+](https://img.shields.io/badge/Python-3.8%2B-blue.svg)
 
-File-based bridge enabling Claude Code to trigger Unity Editor operations in a running editor instance.
+File-based bridge enabling [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to trigger Unity Editor operations in a running editor instance.
 
 ## ✨ Features
 

--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,114 @@
+# Claude Unity Bridge
+
+[![PyPI](https://img.shields.io/pypi/v/claude-unity-bridge)](https://pypi.org/project/claude-unity-bridge/)
+[![Python 3.8+](https://img.shields.io/pypi/pyversions/claude-unity-bridge)](https://pypi.org/project/claude-unity-bridge/)
+[![CI](https://github.com/ManageXR/claude-unity-bridge/actions/workflows/test-skill.yml/badge.svg)](https://github.com/ManageXR/claude-unity-bridge/actions/workflows/test-skill.yml)
+[![codecov](https://codecov.io/gh/ManageXR/claude-unity-bridge/graph/badge.svg?token=3PHF2GXHON)](https://codecov.io/gh/ManageXR/claude-unity-bridge)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/ManageXR/claude-unity-bridge/blob/main/LICENSE)
+[![Unity 2021.3+](https://img.shields.io/badge/Unity-2021.3%2B-black.svg)](https://unity.com/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/claude-unity-bridge)](https://pypi.org/project/claude-unity-bridge/)
+
+> File-based bridge enabling [Claude Code](https://docs.anthropic.com/en/docs/claude-code) to control Unity Editor operations in a running editor instance.
+
+## Why Claude Unity Bridge?
+
+- **Zero config** — No network setup, no port conflicts. Just install and go.
+- **Deterministic CLI** — Tested Python script handles UUIDs, polling, retries, and cleanup so Claude doesn't have to.
+- **Multi-project** — Each Unity project gets its own `.unity-bridge/` directory. Work on multiple projects simultaneously.
+- **Full editor control** — Run tests, compile, check logs, refresh assets, build, and control Play Mode.
+- **Cross-platform** — macOS, Linux, and Windows support.
+
+## Installation
+
+**Install the CLI:**
+
+```bash
+pip install claude-unity-bridge
+unity-bridge install-skill
+```
+
+Or use the one-line installer:
+
+```bash
+# macOS / Linux / Git Bash
+curl -sSL https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.sh | bash
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/ManageXR/claude-unity-bridge/main/install.ps1 | iex
+```
+
+**Add the Unity package** (in Unity Editor):
+
+`Window > Package Manager > + > Add package from git URL...`
+
+```
+https://github.com/ManageXR/claude-unity-bridge.git?path=package
+```
+
+## Quick Start
+
+Open Claude Code in your Unity project directory and ask naturally:
+
+```
+"Run the Unity tests"
+"Check for compilation errors"
+"Show me the error logs"
+"Build for Android"
+```
+
+Or use the CLI directly:
+
+```bash
+unity-bridge run-tests --mode EditMode
+unity-bridge compile
+unity-bridge get-console-logs --limit 10
+unity-bridge get-status
+unity-bridge build --target Android
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `run-tests` | Execute EditMode or PlayMode tests with optional filters |
+| `compile` | Trigger script compilation and report errors |
+| `get-console-logs` | Retrieve Unity console output (filter by Log/Warning/Error) |
+| `get-status` | Check editor state — compilation, play mode, updating |
+| `refresh` | Force asset database refresh |
+| `play` / `pause` / `step` | Control Play Mode — enter, pause, step frames |
+| `build` | Build project with direct pipeline or custom method |
+
+## How It Works
+
+```
+Claude Code  -->  unity-bridge CLI  -->  .unity-bridge/command.json
+                                                  |
+                                            Unity Editor
+                                                  |
+Claude Code  <--  unity-bridge CLI  <--  .unity-bridge/response-{id}.json
+```
+
+1. Claude Code (or you) runs a `unity-bridge` command
+2. The CLI writes a JSON command with a unique UUID
+3. Unity Editor polls for and executes the command
+4. The CLI polls for the response with exponential backoff
+5. Results are formatted and displayed; response files are cleaned up
+
+All file I/O is atomic (temp file + rename) to prevent corruption. The CLI handles file locking, retries, and stale file cleanup automatically.
+
+## Updating
+
+```bash
+unity-bridge update
+```
+
+## Documentation
+
+- [Installation Options](https://github.com/ManageXR/claude-unity-bridge/blob/main/docs/INSTALLATION.md) — Alternative installation methods
+- [Usage Guide](https://github.com/ManageXR/claude-unity-bridge/blob/main/docs/USAGE.md) — Command formats and response details
+- [Architecture](https://github.com/ManageXR/claude-unity-bridge/blob/main/docs/ARCHITECTURE.md) — Project structure and design
+- [Command Reference](https://github.com/ManageXR/claude-unity-bridge/blob/main/skill/references/COMMANDS.md) — Complete command specification
+
+## License
+
+[Apache 2.0](https://github.com/ManageXR/claude-unity-bridge/blob/main/LICENSE)

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -5,10 +5,45 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "claude-unity-bridge"
 version = "0.3.0"
-description = "Control Unity Editor from Claude Code"
-readme = "SKILL.md"
+description = "Control Unity Editor from Claude Code — run tests, compile, get logs, build, and more via a file-based bridge"
+readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
+keywords = [
+    "unity",
+    "claude",
+    "claude-code",
+    "game-development",
+    "unity-editor",
+    "automation",
+    "testing",
+    "bridge",
+    "cli",
+    "ai-agent",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Games/Entertainment",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Testing",
+]
+
+[project.urls]
+Homepage = "https://github.com/ManageXR/claude-unity-bridge"
+Repository = "https://github.com/ManageXR/claude-unity-bridge"
+Issues = "https://github.com/ManageXR/claude-unity-bridge/issues"
+Changelog = "https://github.com/ManageXR/claude-unity-bridge/releases"
+PyPI = "https://pypi.org/project/claude-unity-bridge/"
 
 [project.scripts]
 unity-bridge = "claude_unity_bridge.cli:main"


### PR DESCRIPTION
## Summary

- **New `skill/README.md`** — Dedicated PyPI-facing landing page replacing the 560-line SKILL.md. Includes "Why" section, command table, install instructions, architecture diagram, and absolute GitHub links.
- **Enriched `pyproject.toml` metadata** — Added classifiers (14), keywords (10), project URLs (Homepage, Repo, Issues, Changelog, PyPI), and an expanded description. These populate the PyPI sidebar.
- **Badge bar polish** — Added PyPI version, PyPI downloads, license, and Python version badges to both the repo root README and the PyPI README.

## Before → After

**Before:** PyPI page showed the full SKILL.md technical reference (560 lines of CLI documentation). No classifiers, no keywords, no project URLs in the sidebar.

**After:** Concise landing page with value prop, command table, install flow, and architecture overview. Full sidebar metadata for discoverability. SKILL.md unchanged — still serves its purpose as the Claude Code skill definition.

## Test plan

- [x] 154/154 pytest tests pass
- [x] Pre-commit hooks pass
- [x] `pyproject.toml` metadata validates (all fields parse correctly)
- [x] `skill/README.md` exists and is referenced by `readme = "README.md"`
- [ ] Verify badges render on the PR diff preview
- [ ] After merge + publish: verify PyPI page shows the new README and sidebar metadata