### PR TITLE
fix: cap setuptools <76 for Python 3.8 compatibility

### DIFF
--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "wheel"]
+requires = ["setuptools>=61.0,<76", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary

- Dependabot bumped `setuptools` build requirement to `>=82.0.1` but setuptools 76+ dropped Python 3.8 support
- CI was failing on all Python 3.8 runners (ubuntu, macos, windows) with `No matching distribution found for setuptools>=82.0.1`
- The project declares `requires-python = ">=3.8"`, so the build tool must stay compatible
- Fix: cap to `>=61.0,<76` — 75.x is the last release supporting Python 3.8

## Test plan

- [x] CI passes on Python 3.8 (ubuntu-latest, macos-latest, windows-latest)
- [x] CI passes on Python 3.9–3.12 (no change for those)