### PR TITLE
fix: drop Python 3.8 support to unblock setuptools updates

### DIFF
--- a/.github/workflows/test-skill.yml
+++ b/.github/workflows/test-skill.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 
     steps:

--- a/skill/pyproject.toml
+++ b/skill/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.0"
 description = "Control Unity Editor from Claude Code — run tests, compile, get logs, build, and more via a file-based bridge"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "unity",
     "claude",
@@ -28,7 +28,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- Drop Python 3.8 (EOL October 2024) from CI matrix, classifiers, and `requires-python`
- Minimum is now Python 3.9
- Unblocks setuptools updates — dependabot kept bumping past v76 which doesn't support 3.8, breaking CI (#57, #58)

## Test plan
- [ ] CI passes on 3.9, 3.10, 3.11, 3.12 across all OS targets
- [ ] Lint job still passes